### PR TITLE
Fix delayed secret flag initialization

### DIFF
--- a/app/vmagent/main.go
+++ b/app/vmagent/main.go
@@ -111,6 +111,7 @@ func main() {
 	flag.CommandLine.SetOutput(os.Stdout)
 	flag.Usage = usage
 	envflag.Parse()
+	flagutil.ApplySecretFlags()
 	remotewrite.InitSecretFlags()
 	buildinfo.Init()
 	logger.Init()

--- a/app/vmalert/main.go
+++ b/app/vmalert/main.go
@@ -91,6 +91,7 @@ func main() {
 	flag.CommandLine.SetOutput(os.Stdout)
 	flag.Usage = usage
 	envflag.Parse()
+	flagutil.ApplySecretFlags()
 	remoteread.InitSecretFlags()
 	remotewrite.InitSecretFlags()
 	datasource.InitSecretFlags()

--- a/lib/flagutil/secret.go
+++ b/lib/flagutil/secret.go
@@ -22,12 +22,6 @@ var secretFlags = make(map[string]bool)
 var secretFlagsList = NewArrayString("secret.flags",
 	"Comma-separated list of flag names with secret values. Values for these flags are hidden in logs and on /metrics page")
 
-func init() {
-	for _, f := range *secretFlagsList {
-		RegisterSecretFlag(f)
-	}
-}
-
 // ApplySecretFlags registers flags from `-secret.flags` after they are parsed.
 //
 // This function must be called after flag.Parse and before starting logging.

--- a/lib/flagutil/secret.go
+++ b/lib/flagutil/secret.go
@@ -16,9 +16,22 @@ func RegisterSecretFlag(flagName string) {
 }
 
 var secretFlags = make(map[string]bool)
-var secretFlagsList = NewArrayString("secret.flags", "Comma-separated list of flag names with secret values. Values for these flags are hidden in logs and on /metrics page")
+
+// secretFlagsList contains names of flags with secret values obtained from
+// the `-secret.flags` command-line option.
+var secretFlagsList = NewArrayString("secret.flags",
+	"Comma-separated list of flag names with secret values. Values for these flags are hidden in logs and on /metrics page")
 
 func init() {
+	for _, f := range *secretFlagsList {
+		RegisterSecretFlag(f)
+	}
+}
+
+// ApplySecretFlags registers flags from `-secret.flags` after they are parsed.
+//
+// This function must be called after flag.Parse and before starting logging.
+func ApplySecretFlags() {
 	for _, f := range *secretFlagsList {
 		RegisterSecretFlag(f)
 	}

--- a/lib/flagutil/secret_test.go
+++ b/lib/flagutil/secret_test.go
@@ -1,0 +1,19 @@
+package flagutil
+
+import "testing"
+
+func TestApplySecretFlags(t *testing.T) {
+	secretFlags = make(map[string]bool)
+	secretFlagsList = &ArrayString{}
+	secretFlagsList.Set("foo,bar")
+
+	if IsSecretFlag("foo") || IsSecretFlag("bar") {
+		t.Fatalf("flags are secret before ApplySecretFlags")
+	}
+
+	ApplySecretFlags()
+
+	if !IsSecretFlag("foo") || !IsSecretFlag("bar") {
+		t.Fatalf("ApplySecretFlags didn't mark flags as secret")
+	}
+}


### PR DESCRIPTION
## Summary
- expose `ApplySecretFlags` so flags from `-secret.flags` can be registered after parsing
- call `ApplySecretFlags` in `vmagent` and `vmalert` before logger init
- add unit test for `ApplySecretFlags`

## Testing
- `go vet ./lib/flagutil/... ./app/vmagent/... ./app/vmalert/...`
- `go test ./lib/flagutil -run TestApplySecretFlags -v`
- `go test ./app/vmagent -run TestNothing -v`
- `go test ./app/vmalert -run TestNothing -v`


------
https://chatgpt.com/codex/tasks/task_e_6844e4a9c288832f8f76c91af8c85735